### PR TITLE
Let coin_market_cap loop through the pages untill coin is found

### DIFF
--- a/lib/capwatch/coin.rb
+++ b/lib/capwatch/coin.rb
@@ -7,10 +7,20 @@ module Capwatch
                   :distribution,
                   :percent_change_1h,
                   :percent_change_24h,
-                  :percent_change_7d
+                  :percent_change_7d,
+                  :fiat_currency
 
     def initialize
       yield self if block_given?
+    end
+
+    def attributes=(attributes)
+      self.name               = attributes['name']
+      self.price_fiat         = attributes[price_attribute].to_f
+      self.price_btc          = attributes['price_btc'].to_f
+      self.percent_change_1h  = attributes['percent_change_1h'].to_f
+      self.percent_change_24h = attributes['percent_change_24h'].to_f
+      self.percent_change_7d  = attributes['percent_change_7d'].to_f
     end
 
     def value_btc
@@ -47,5 +57,10 @@ module Capwatch
       }
     end
 
+    private
+
+    def price_attribute
+      "price_#{fiat_currency.downcase}"
+    end
   end
 end

--- a/lib/capwatch/fund/config.rb
+++ b/lib/capwatch/fund/config.rb
@@ -23,8 +23,9 @@ module Capwatch
       def coins
         positions.map do |symbol, quantity|
           Coin.new do |coin|
-            coin.symbol   = symbol
-            coin.quantity = quantity
+            coin.fiat_currency = currency
+            coin.symbol        = symbol
+            coin.quantity      = quantity
           end
         end
       end

--- a/lib/capwatch/providers/coin_market_cap.rb
+++ b/lib/capwatch/providers/coin_market_cap.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "json"
-require "open-uri"
+require 'json'
+require 'open-uri'
 
 module Capwatch
   module Providers
@@ -11,7 +11,7 @@ module Capwatch
 
       NoCoinInProvider = Class.new(RuntimeError)
 
-      TICKER_URL = "https://api.coinmarketcap.com/v1/ticker/"
+      TICKER_URL = 'https://api.coinmarketcap.com/v1/ticker/'
       PAGE_LIMIT = 100
       FIRST_PAGE = 0
 
@@ -32,7 +32,7 @@ module Capwatch
         response.each do |coin_json|
           Capwatch::Exchange.rate(
             coin_json['symbol'],
-            coin_json["price_btc"].to_f
+            coin_json['price_btc'].to_f
           )
         end
       end
@@ -42,20 +42,20 @@ module Capwatch
           body = open(ticker_url(limit: limit, start: start)).read
           coins = update_rates(parse(body))
         rescue OpenURI::HTTPError => err
-          fail unless err.message == "404 NOT FOUND"
+          fail unless err.message == '404 NOT FOUND'
           fail_no_coin(coin.symbol)
         end
 
-        provider_coin = coins.find { |c| c["symbol"] == coin.symbol }
+        provider_coin = coins.find { |c| c['symbol'] == coin.symbol }
         if provider_coin.nil?
           update_coin(coin, limit: limit, start: start += limit)
         else
-          coin.name               = provider_coin["name"]
+          coin.name               = provider_coin['name']
           coin.price_fiat         = provider_coin[price_attribute].to_f
-          coin.price_btc          = provider_coin["price_btc"].to_f
-          coin.percent_change_1h  = provider_coin["percent_change_1h"].to_f
-          coin.percent_change_24h = provider_coin["percent_change_24h"].to_f
-          coin.percent_change_7d  = provider_coin["percent_change_7d"].to_f
+          coin.price_btc          = provider_coin['price_btc'].to_f
+          coin.percent_change_1h  = provider_coin['percent_change_1h'].to_f
+          coin.percent_change_24h = provider_coin['percent_change_24h'].to_f
+          coin.percent_change_7d  = provider_coin['percent_change_7d'].to_f
         end
         coin
       end

--- a/lib/capwatch/providers/coin_market_cap.rb
+++ b/lib/capwatch/providers/coin_market_cap.rb
@@ -6,25 +6,22 @@ require "open-uri"
 module Capwatch
   module Providers
     class CoinMarketCap
-
       attr_accessor :body
       attr_reader :config
 
       NoCoinInProvider = Class.new(RuntimeError)
 
       TICKER_URL = "https://api.coinmarketcap.com/v1/ticker/"
+      PAGE_LIMIT = 100
+      FIRST_PAGE = 0
 
       def initialize(config:)
         @config = config
       end
 
       def fetched_json
-        response = parse(fetch)
-        update_rates(response)
-      end
-
-      def fetch
-        @body ||= open(ticker_url).read
+        body = open(ticker_url).read
+        update_rates(parse(body))
       end
 
       def parse(response)
@@ -40,29 +37,42 @@ module Capwatch
         end
       end
 
-      def update_coin(coin)
-        provider_coin = fetched_json.find { |c| c["symbol"] == coin.symbol }
-        fail NoCoinInProvider, "No #{coin.symbol} in provider response" if provider_coin.nil?
-        coin.name               = provider_coin["name"]
-        coin.price_fiat         = provider_coin[price_attribute].to_f
-        coin.price_btc          = provider_coin["price_btc"].to_f
-        coin.percent_change_1h  = provider_coin["percent_change_1h"].to_f
-        coin.percent_change_24h = provider_coin["percent_change_24h"].to_f
-        coin.percent_change_7d  = provider_coin["percent_change_7d"].to_f
+      def update_coin(coin, limit: PAGE_LIMIT, start: FIRST_PAGE)
+        begin
+          body = open(ticker_url(limit: limit, start: start)).read
+          coins = update_rates(parse(body))
+        rescue OpenURI::HTTPError => err
+          fail unless err.message == "404 NOT FOUND"
+          fail_no_coin(coin.symbol)
+        end
+
+        provider_coin = coins.find { |c| c["symbol"] == coin.symbol }
+        if provider_coin.nil?
+          update_coin(coin, limit: limit, start: start += limit)
+        else
+          coin.name               = provider_coin["name"]
+          coin.price_fiat         = provider_coin[price_attribute].to_f
+          coin.price_btc          = provider_coin["price_btc"].to_f
+          coin.percent_change_1h  = provider_coin["percent_change_1h"].to_f
+          coin.percent_change_24h = provider_coin["percent_change_24h"].to_f
+          coin.percent_change_7d  = provider_coin["percent_change_7d"].to_f
+        end
+        coin
       end
 
       private
 
-      def ticker_url
-        "#{TICKER_URL}?limit=300&convert=#{config.currency}"
+      def ticker_url(limit: PAGE_LIMIT, start: 0)
+        "#{TICKER_URL}?convert=#{config.currency}&limit=#{limit}&start=#{start}"
       end
 
       def price_attribute
         "price_#{config.currency.downcase}"
       end
 
+      def fail_no_coin(symbol)
+        fail NoCoinInProvider, "No #{symbol} in provider response"
+      end
     end # class CoinMarketCap
-
   end # module Providers
-
 end

--- a/lib/capwatch/providers/coin_market_cap.rb
+++ b/lib/capwatch/providers/coin_market_cap.rb
@@ -50,12 +50,7 @@ module Capwatch
         if provider_coin.nil?
           update_coin(coin, limit: limit, start: start += limit)
         else
-          coin.name               = provider_coin['name']
-          coin.price_fiat         = provider_coin[price_attribute].to_f
-          coin.price_btc          = provider_coin['price_btc'].to_f
-          coin.percent_change_1h  = provider_coin['percent_change_1h'].to_f
-          coin.percent_change_24h = provider_coin['percent_change_24h'].to_f
-          coin.percent_change_7d  = provider_coin['percent_change_7d'].to_f
+          coin.attributes = provider_coin
         end
         coin
       end
@@ -64,10 +59,6 @@ module Capwatch
 
       def ticker_url(limit: PAGE_LIMIT, start: 0)
         "#{TICKER_URL}?convert=#{config.currency}&limit=#{limit}&start=#{start}"
-      end
-
-      def price_attribute
-        "price_#{config.currency.downcase}"
       end
 
       def fail_no_coin(symbol)

--- a/spec/capwatch/fund_spec.rb
+++ b/spec/capwatch/fund_spec.rb
@@ -3,14 +3,6 @@
 require "spec_helper"
 
 RSpec.describe Capwatch::Fund do
-
-  let(:unknown_coin) do
-    Capwatch::Coin.new do |coin|
-      coin.symbol = 'UNKNOWN_COIN'
-      coin.quantity = 5_000
-    end
-  end
-
   let(:config_name) { "Test Config" }
 
   let(:config_positions) do
@@ -28,8 +20,7 @@ RSpec.describe Capwatch::Fund do
   end
 
   let(:provider) do
-    p = Capwatch::Providers::CoinMarketCap.new(config: config)
-    p.body = [
+    tokens =  [
       {
           "id": "bitcoin",
           "name": "Bitcoin",
@@ -62,24 +53,15 @@ RSpec.describe Capwatch::Fund do
           "percent_change_7d": "13.06",
           "last_updated": "1502666050"
       }
-    ].to_json
-    p
+    ]
+
+    response = double("HTTP::Response", read: tokens.to_json)
+    provider = Capwatch::Providers::CoinMarketCap.new(config: config)
+    allow(provider).to receive(:open).and_return(response)
+    provider
   end
 
   subject { described_class.new(config: config, provider: provider) }
-
-  context "initialize" do
-
-    it "raise ex ecaption if coin cannot be matched with provider" do
-      subject.coins << unknown_coin
-      expect{ subject.build }
-        .to raise_exception(
-          Capwatch::Providers::CoinMarketCap::NoCoinInProvider,
-          "No UNKNOWN_COIN in provider response"
-        )
-    end
-
-  end
 
   context "#[]" do
 

--- a/spec/capwatch/fund_spec.rb
+++ b/spec/capwatch/fund_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Capwatch::Fund do
-  let(:config_name) { "Test Config" }
+  let(:config_name) { 'Test Config' }
 
   let(:config_positions) do
-    JSON.parse({ "BTC": 10, "ETH": 20 }.to_json)
+    JSON.parse({ 'BTC': 10, 'ETH': 20 }.to_json)
   end
 
   let(:config_currency) { 'USD' }
@@ -22,40 +22,40 @@ RSpec.describe Capwatch::Fund do
   let(:provider) do
     tokens =  [
       {
-          "id": "bitcoin",
-          "name": "Bitcoin",
-          "symbol": "BTC",
-          "rank": "1",
-          "price_usd": "4082.92",
-          "price_btc": "1.0",
-          "24h_volume_usd": "3178380000.0",
-          "market_cap_usd": "67389717403.0",
-          "available_supply": "16505275.0",
-          "total_supply": "16505275.0",
-          "percent_change_1h": "-0.6",
-          "percent_change_24h": "5.76",
-          "percent_change_7d": "26.08",
-          "last_updated": "1502666052"
+          'id': 'bitcoin',
+          'name': 'Bitcoin',
+          'symbol': 'BTC',
+          'rank': '1',
+          'price_usd': '4082.92',
+          'price_btc': '1.0',
+          '24h_volume_usd': '3178380000.0',
+          'market_cap_usd': '67389717403.0',
+          'available_supply': '16505275.0',
+          'total_supply': '16505275.0',
+          'percent_change_1h': '-0.6',
+          'percent_change_24h': '5.76',
+          'percent_change_7d': '26.08',
+          'last_updated': '1502666052'
       },
       {
-          "id": "ethereum",
-          "name": "Ethereum",
-          "symbol": "ETH",
-          "rank": "2",
-          "price_usd": "298.824",
-          "price_btc": "0.0731086",
-          "24h_volume_usd": "1371430000.0",
-          "market_cap_usd": "28082931934.0",
-          "available_supply": "93978168.0",
-          "total_supply": "93978168.0",
-          "percent_change_1h": "0.58",
-          "percent_change_24h": "-3.69",
-          "percent_change_7d": "13.06",
-          "last_updated": "1502666050"
+          'id': 'ethereum',
+          'name': 'Ethereum',
+          'symbol': 'ETH',
+          'rank': '2',
+          'price_usd': '298.824',
+          'price_btc': '0.0731086',
+          '24h_volume_usd': '1371430000.0',
+          'market_cap_usd': '28082931934.0',
+          'available_supply': '93978168.0',
+          'total_supply': '93978168.0',
+          'percent_change_1h': '0.58',
+          'percent_change_24h': '-3.69',
+          'percent_change_7d': '13.06',
+          'last_updated': '1502666050'
       }
     ]
 
-    response = double("HTTP::Response", read: tokens.to_json)
+    response = double('HTTP::Response', read: tokens.to_json)
     provider = Capwatch::Providers::CoinMarketCap.new(config: config)
     allow(provider).to receive(:open).and_return(response)
     provider
@@ -63,103 +63,103 @@ RSpec.describe Capwatch::Fund do
 
   subject { described_class.new(config: config, provider: provider) }
 
-  context "#[]" do
+  context '#[]' do
 
-    it "find the right coin by symbol name" do
-      expect(subject["ETH"].quantity).to eq 20
+    it 'find the right coin by symbol name' do
+      expect(subject['ETH'].quantity).to eq 20
     end
 
-    it "returns nil if exeption if symbol name not found" do
-      expect(subject["XXX"]).to eq nil
+    it 'returns nil if exeption if symbol name not found' do
+      expect(subject['XXX']).to eq nil
     end
 
   end
 
-  context "aggregations" do
+  context 'aggregations' do
 
-    context "sepetate coins" do
+    context 'sepetate coins' do
 
-      it "#price_btc" do
+      it '#price_btc' do
         subject
-        expect(subject["BTC"].price_btc).to eq 1.0
-        expect(subject["ETH"].price_btc).to eq 0.0731086
+        expect(subject['BTC'].price_btc).to eq 1.0
+        expect(subject['ETH'].price_btc).to eq 0.0731086
       end
 
-      it "#price_fiat" do
+      it '#price_fiat' do
         subject
-        expect(subject["BTC"].price_fiat).to eq 4082.92
-        expect(subject["ETH"].price_fiat).to eq 298.824
+        expect(subject['BTC'].price_fiat).to eq 4082.92
+        expect(subject['ETH'].price_fiat).to eq 298.824
       end
 
-      it "#price_eth" do
+      it '#price_eth' do
         subject
-        expect(subject["BTC"].price_eth).to eq 1 / 0.0731086
-        expect(subject["ETH"].price_eth).to eq 1
+        expect(subject['BTC'].price_eth).to eq 1 / 0.0731086
+        expect(subject['ETH'].price_eth).to eq 1
       end
 
-      it "#value_btc" do
+      it '#value_btc' do
         subject
-        expect(subject["BTC"].value_btc).to eq 1.0 * 10
-        expect(subject["ETH"].value_btc).to eq 0.0731086 * 20
+        expect(subject['BTC'].value_btc).to eq 1.0 * 10
+        expect(subject['ETH'].value_btc).to eq 0.0731086 * 20
       end
 
-      it "#value_fiat" do
-        expect(subject["BTC"].value_fiat).to eq 4082.92 * 10
-        expect(subject["ETH"].value_fiat).to eq 298.824 * 20
+      it '#value_fiat' do
+        expect(subject['BTC'].value_fiat).to eq 4082.92 * 10
+        expect(subject['ETH'].value_fiat).to eq 298.824 * 20
       end
 
-      it "#value_eth" do
-        expect(subject["BTC"].value_eth).to eq 10 * 1.0 / 0.0731086
-        expect(subject["ETH"].value_eth).to eq 1 * 20
+      it '#value_eth' do
+        expect(subject['BTC'].value_eth).to eq 10 * 1.0 / 0.0731086
+        expect(subject['ETH'].value_eth).to eq 1 * 20
       end
 
-      it "#distribution" do
-        expect(subject["BTC"].distribution).to eq 1.0 * 10 / (1.0 * 10 + 0.0731086 * 20)
-        expect(subject["ETH"].distribution).to eq 0.0731086 * 20 / (1.0 * 10 + 0.0731086 * 20)
+      it '#distribution' do
+        expect(subject['BTC'].distribution).to eq 1.0 * 10 / (1.0 * 10 + 0.0731086 * 20)
+        expect(subject['ETH'].distribution).to eq 0.0731086 * 20 / (1.0 * 10 + 0.0731086 * 20)
       end
 
-      it "total distribution is 100%" do
-        expect((subject["BTC"].distribution + subject["ETH"].distribution)).to eq 1.0
+      it 'total distribution is 100%' do
+        expect((subject['BTC'].distribution + subject['ETH'].distribution)).to eq 1.0
       end
 
     end
 
-    context "whole fund" do
+    context 'whole fund' do
 
-      it "#value_btc" do
+      it '#value_btc' do
         expect(subject.value_btc).to eq 1.0 * 10 + 0.0731086 * 20
       end
 
-      it "#value_fiat" do
+      it '#value_fiat' do
         expect(subject.value_fiat).to eq 4082.92 * 10 + 298.824 * 20
       end
 
-      it "#value_eth" do
+      it '#value_eth' do
         expect(subject.value_eth).to eq 1 * 20 + 10 / 0.0731086 / 1.0
       end
 
-      it "#percent_change_1h" do
+      it '#percent_change_1h' do
         expect(subject.percent_change_1h).to eq -0.44947329703305805
       end
 
-      it "#percent_change_24h" do
+      it '#percent_change_24h' do
         expect(subject.percent_change_24h).to eq 4.554510726239321
       end
 
-      it "#percent_change_7d" do
+      it '#percent_change_7d' do
         expect(subject.percent_change_7d).to eq 24.419103667263066
       end
 
     end
 
-    context "serialize" do
-      it "#serialize" do
+    context 'serialize' do
+      it '#serialize' do
         expect(JSON.parse(subject.serialize).size).to eq 2
       end
     end
 
-    context "console" do
-      it "#console_table" do
+    context 'console' do
+      it '#console_table' do
         expect(subject.console_table).to be_kind_of(Terminal::Table)
       end
     end

--- a/spec/capwatch/providers/coin_market_cap_spec.rb
+++ b/spec/capwatch/providers/coin_market_cap_spec.rb
@@ -4,20 +4,74 @@ require "spec_helper"
 require "ostruct"
 
 RSpec.describe Capwatch::Providers::CoinMarketCap do
-
-  let(:config) { OpenStruct.new(currency: "EUR") }
   subject { Capwatch::Providers::CoinMarketCap.new(config: config) }
 
-  let(:response) { Hash.new }
+  let(:config) { OpenStruct.new(currency: "EUR") }
+  let(:response) do
+    [{ "symbol" => "BTC", "name" => "Bitcoin", price_btc: 1 }].to_json
+  end
+  let(:btc) { OpenStruct.new(symbol: "BTC") }
+  let(:unknown_coin) { OpenStruct.new(symbol: "UNKNOWN_COIN") }
+  let(:not_found) { OpenURI::HTTPError.new("404 NOT FOUND", StringIO.new) }
+
   before do
     allow(subject).to receive(:open).and_return(OpenStruct.new(read: response))
   end
 
-  describe "fetch" do
-    it "fetches using the currency as convert attribute" do
-      expected_url = "https://api.coinmarketcap.com/v1/ticker/?convert=EUR"
+  describe "update_coin" do
+    it "paginates through the results until the request contains the coin" do
+      expect(subject).to receive(:open).
+        with(/&start=0/).ordered.
+        and_return(OpenStruct.new(read: [].to_json))
+      expect(subject).to receive(:open).
+        with(/&start=100$/).ordered.
+        and_return(OpenStruct.new(read: response))
+
+      expect(subject.update_coin(btc).name).to eq("Bitcoin")
+    end
+
+    it "paginates through the results until the request gives a 404" do
+      expect(subject).to receive(:open).
+        with(/&start=0/).ordered.
+        and_return(OpenStruct.new(read: response))
+      expect(subject).to receive(:open).
+        with(/&start=100$/).ordered.
+        and_raise(not_found)
+
+      expect { subject.update_coin(unknown_coin) }.to raise_exception(
+        Capwatch::Providers::CoinMarketCap::NoCoinInProvider,
+        "No UNKNOWN_COIN in provider response"
+      )
+    end
+
+    it "raise exception if coin cannot be found in any page" do
+      allow(subject).to receive(:open).and_raise(not_found)
+      expect { subject.update_coin(unknown_coin) }.to raise_exception(
+        Capwatch::Providers::CoinMarketCap::NoCoinInProvider,
+        "No UNKNOWN_COIN in provider response"
+      )
+    end
+
+    it "reraises the OpenURI::HTTPError when it is not a 404" do
+      err = OpenURI::HTTPError.new("500", StringIO.new)
+      allow(subject).to receive(:open).and_raise(err)
+      expect { subject.update_coin(unknown_coin) }.to raise_exception(err)
+    end
+
+    it "fetches the data from v1 ticket API" do
+      expected_url = %r{https://api.coinmarketcap.com/v1/ticker/}
       expect(subject).to receive(:open).with(expected_url)
-      subject.fetch
+      subject.update_coin(btc)
+    end
+
+    it "fetches using the currency as convert attribute" do
+      expect(subject).to receive(:open).with(/\?convert=EUR/)
+      subject.update_coin(btc)
+    end
+
+    it "fetches the coin using limit 10" do
+      expect(subject).to receive(:open).with(/limit=10/)
+      subject.update_coin(btc)
     end
   end
 end

--- a/spec/capwatch/providers/coin_market_cap_spec.rb
+++ b/spec/capwatch/providers/coin_market_cap_spec.rb
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-require "ostruct"
+require 'spec_helper'
+require 'ostruct'
 
 RSpec.describe Capwatch::Providers::CoinMarketCap do
   subject { Capwatch::Providers::CoinMarketCap.new(config: config) }
 
-  let(:config) { OpenStruct.new(currency: "EUR") }
+  let(:config) { OpenStruct.new(currency: 'EUR') }
   let(:response) do
-    [{ "symbol" => "BTC", "name" => "Bitcoin", price_btc: 1 }].to_json
+    [{ 'symbol' => 'BTC', 'name' => 'Bitcoin', price_btc: 1 }].to_json
   end
-  let(:btc) { OpenStruct.new(symbol: "BTC") }
-  let(:unknown_coin) { OpenStruct.new(symbol: "UNKNOWN_COIN") }
-  let(:not_found) { OpenURI::HTTPError.new("404 NOT FOUND", StringIO.new) }
+  let(:btc) { OpenStruct.new(symbol: 'BTC') }
+  let(:unknown_coin) { OpenStruct.new(symbol: 'UNKNOWN_COIN') }
+  let(:not_found) { OpenURI::HTTPError.new('404 NOT FOUND', StringIO.new) }
 
   before do
     allow(subject).to receive(:open).and_return(OpenStruct.new(read: response))
   end
 
-  describe "update_coin" do
-    it "paginates through the results until the request contains the coin" do
+  describe 'update_coin' do
+    it 'paginates through the results until the request contains the coin' do
       expect(subject).to receive(:open).
         with(/&start=0/).ordered.
         and_return(OpenStruct.new(read: [].to_json))
@@ -27,10 +27,10 @@ RSpec.describe Capwatch::Providers::CoinMarketCap do
         with(/&start=100$/).ordered.
         and_return(OpenStruct.new(read: response))
 
-      expect(subject.update_coin(btc).name).to eq("Bitcoin")
+      expect(subject.update_coin(btc).name).to eq('Bitcoin')
     end
 
-    it "paginates through the results until the request gives a 404" do
+    it 'paginates through the results until the request gives a 404' do
       expect(subject).to receive(:open).
         with(/&start=0/).ordered.
         and_return(OpenStruct.new(read: response))
@@ -40,36 +40,36 @@ RSpec.describe Capwatch::Providers::CoinMarketCap do
 
       expect { subject.update_coin(unknown_coin) }.to raise_exception(
         Capwatch::Providers::CoinMarketCap::NoCoinInProvider,
-        "No UNKNOWN_COIN in provider response"
+        'No UNKNOWN_COIN in provider response'
       )
     end
 
-    it "raise exception if coin cannot be found in any page" do
+    it 'raise exception if coin cannot be found in any page' do
       allow(subject).to receive(:open).and_raise(not_found)
       expect { subject.update_coin(unknown_coin) }.to raise_exception(
         Capwatch::Providers::CoinMarketCap::NoCoinInProvider,
-        "No UNKNOWN_COIN in provider response"
+        'No UNKNOWN_COIN in provider response'
       )
     end
 
-    it "reraises the OpenURI::HTTPError when it is not a 404" do
-      err = OpenURI::HTTPError.new("500", StringIO.new)
+    it 'reraises the OpenURI::HTTPError when it is not a 404' do
+      err = OpenURI::HTTPError.new('500', StringIO.new)
       allow(subject).to receive(:open).and_raise(err)
       expect { subject.update_coin(unknown_coin) }.to raise_exception(err)
     end
 
-    it "fetches the data from v1 ticket API" do
+    it 'fetches the data from v1 ticket API' do
       expected_url = %r{https://api.coinmarketcap.com/v1/ticker/}
       expect(subject).to receive(:open).with(expected_url)
       subject.update_coin(btc)
     end
 
-    it "fetches using the currency as convert attribute" do
+    it 'fetches using the currency as convert attribute' do
       expect(subject).to receive(:open).with(/\?convert=EUR/)
       subject.update_coin(btc)
     end
 
-    it "fetches the coin using limit 10" do
+    it 'fetches the coin using limit 10' do
       expect(subject).to receive(:open).with(/limit=10/)
       subject.update_coin(btc)
     end

--- a/spec/capwatch/providers/coin_market_cap_spec.rb
+++ b/spec/capwatch/providers/coin_market_cap_spec.rb
@@ -18,60 +18,58 @@ RSpec.describe Capwatch::Providers::CoinMarketCap do
     allow(subject).to receive(:open).and_return(OpenStruct.new(read: response))
   end
 
-  describe 'update_coin' do
-    it 'paginates through the results until the request contains the coin' do
-      expect(subject).to receive(:open)
-        .with(/&start=0/).ordered
-        .and_return(OpenStruct.new(read: [].to_json))
-      expect(subject).to receive(:open)
-        .with(/&start=100$/).ordered
-        .and_return(OpenStruct.new(read: response))
+  it 'paginates through the results until the request contains the coin' do
+    expect(subject).to receive(:open)
+      .with(/&start=0/).ordered
+      .and_return(OpenStruct.new(read: [].to_json))
+    expect(subject).to receive(:open)
+      .with(/&start=100$/).ordered
+      .and_return(OpenStruct.new(read: response))
 
-      expect(subject.update_coin(btc).name).to eq('Bitcoin')
-    end
+    subject.update_coin(btc)
+  end
 
-    it 'paginates through the results until the request gives a 404' do
-      expect(subject).to receive(:open)
-        .with(/&start=0/).ordered
-        .and_return(OpenStruct.new(read: response))
-      expect(subject).to receive(:open)
-        .with(/&start=100$/).ordered
-        .and_raise(not_found)
+  it 'paginates through the results until the request gives a 404' do
+    expect(subject).to receive(:open)
+      .with(/&start=0/).ordered
+      .and_return(OpenStruct.new(read: response))
+    expect(subject).to receive(:open)
+      .with(/&start=100$/).ordered
+      .and_raise(not_found)
 
-      expect { subject.update_coin(unknown_coin) }.to raise_exception(
-        Capwatch::Providers::CoinMarketCap::NoCoinInProvider,
-        'No UNKNOWN_COIN in provider response'
-      )
-    end
+    expect { subject.update_coin(unknown_coin) }.to raise_exception(
+      Capwatch::Providers::CoinMarketCap::NoCoinInProvider,
+      'No UNKNOWN_COIN in provider response'
+    )
+  end
 
-    it 'raise exception if coin cannot be found in any page' do
-      allow(subject).to receive(:open).and_raise(not_found)
-      expect { subject.update_coin(unknown_coin) }.to raise_exception(
-        Capwatch::Providers::CoinMarketCap::NoCoinInProvider,
-        'No UNKNOWN_COIN in provider response'
-      )
-    end
+  it 'raise exception if coin cannot be found in any page' do
+    allow(subject).to receive(:open).and_raise(not_found)
+    expect { subject.update_coin(unknown_coin) }.to raise_exception(
+      Capwatch::Providers::CoinMarketCap::NoCoinInProvider,
+      'No UNKNOWN_COIN in provider response'
+    )
+  end
 
-    it 'reraises the OpenURI::HTTPError when it is not a 404' do
-      err = OpenURI::HTTPError.new('500', StringIO.new)
-      allow(subject).to receive(:open).and_raise(err)
-      expect { subject.update_coin(unknown_coin) }.to raise_exception(err)
-    end
+  it 'reraises the OpenURI::HTTPError when it is not a 404' do
+    err = OpenURI::HTTPError.new('500', StringIO.new)
+    allow(subject).to receive(:open).and_raise(err)
+    expect { subject.update_coin(unknown_coin) }.to raise_exception(err)
+  end
 
-    it 'fetches the data from v1 ticket API' do
-      expected_url = %r{https://api.coinmarketcap.com/v1/ticker/}
-      expect(subject).to receive(:open).with(expected_url)
-      subject.update_coin(btc)
-    end
+  it 'fetches the data from v1 ticket API' do
+    expected_url = %r{https://api.coinmarketcap.com/v1/ticker/}
+    expect(subject).to receive(:open).with(expected_url)
+    subject.update_coin(btc)
+  end
 
-    it 'fetches using the currency as convert attribute' do
-      expect(subject).to receive(:open).with(/\?convert=EUR/)
-      subject.update_coin(btc)
-    end
+  it 'fetches using the currency as convert attribute' do
+    expect(subject).to receive(:open).with(/\?convert=EUR/)
+    subject.update_coin(btc)
+  end
 
-    it 'fetches the coin using limit 10' do
-      expect(subject).to receive(:open).with(/limit=10/)
-      subject.update_coin(btc)
-    end
+  it 'fetches the coin using limit 10' do
+    expect(subject).to receive(:open).with(/limit=10/)
+    subject.update_coin(btc)
   end
 end

--- a/spec/capwatch/providers/coin_market_cap_spec.rb
+++ b/spec/capwatch/providers/coin_market_cap_spec.rb
@@ -20,23 +20,23 @@ RSpec.describe Capwatch::Providers::CoinMarketCap do
 
   describe 'update_coin' do
     it 'paginates through the results until the request contains the coin' do
-      expect(subject).to receive(:open).
-        with(/&start=0/).ordered.
-        and_return(OpenStruct.new(read: [].to_json))
-      expect(subject).to receive(:open).
-        with(/&start=100$/).ordered.
-        and_return(OpenStruct.new(read: response))
+      expect(subject).to receive(:open)
+        .with(/&start=0/).ordered
+        .and_return(OpenStruct.new(read: [].to_json))
+      expect(subject).to receive(:open)
+        .with(/&start=100$/).ordered
+        .and_return(OpenStruct.new(read: response))
 
       expect(subject.update_coin(btc).name).to eq('Bitcoin')
     end
 
     it 'paginates through the results until the request gives a 404' do
-      expect(subject).to receive(:open).
-        with(/&start=0/).ordered.
-        and_return(OpenStruct.new(read: response))
-      expect(subject).to receive(:open).
-        with(/&start=100$/).ordered.
-        and_raise(not_found)
+      expect(subject).to receive(:open)
+        .with(/&start=0/).ordered
+        .and_return(OpenStruct.new(read: response))
+      expect(subject).to receive(:open)
+        .with(/&start=100$/).ordered
+        .and_raise(not_found)
 
       expect { subject.update_coin(unknown_coin) }.to raise_exception(
         Capwatch::Providers::CoinMarketCap::NoCoinInProvider,


### PR DESCRIPTION
I got a `NoCoinInProvider` exception now and then. Turns out, this coin dropped below the 200 most poular ones now and a again. 

This PR lets us walk over the pages of the API. 

This allows a portfolio to have much more than just the top200 coins, it allows every coin the API lists.

Added benefit is that the fetching of popular coins is now a little faster (gets top 100, not top 200). 
The API does get slow on very rare coins: response times of seconds is not unusual. So, if you list one or more very rare coins, expect the watch feature to take several seconds before it shows up.